### PR TITLE
feat(auth): email + password sign-in flow

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,6 +37,9 @@
     "experiments": {
       "reactCompiler": true
     },
-    "owner": "jose1992"
+    "owner": "jose1992",
+    "plugins": [
+      "expo-secure-store"
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@supabase/supabase-js": "^2.104.1",
         "expo": "^55.0.17",
         "expo-haptics": "~55.0.14",
+        "expo-secure-store": "~55.0.13",
         "expo-status-bar": "~55.0.5",
         "lottie-react-native": "~7.3.4",
         "phosphor-react-native": "^1.1.2",
@@ -8077,6 +8078,15 @@
         "react-native-worklets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-55.0.13.tgz",
+      "integrity": "sha512-I6r0JNO1Fd4o0Gu7Ixiic7s89lqgdUHq17uBH9y1f/AntoyKn71TdtYJH82RgfsBbu5qNVzrwImmvlANyOlITQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-server": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@supabase/supabase-js": "^2.104.1",
     "expo": "^55.0.17",
     "expo-haptics": "~55.0.14",
+    "expo-secure-store": "~55.0.13",
     "expo-status-bar": "~55.0.5",
     "lottie-react-native": "~7.3.4",
     "phosphor-react-native": "^1.1.2",

--- a/src/@types/navigation.d.ts
+++ b/src/@types/navigation.d.ts
@@ -1,9 +1,13 @@
 export declare global {
   namespace ReactNavigation {
     interface RootParamList {
-      signin: undefined;
+      signIn: undefined;
+      signUp: undefined;
+      forgotPassword: undefined;
+      checkEmail: { email?: string } | undefined;
+      resetPassword: undefined;
       home: undefined;
-      postgame: { status: tryagain | youwin };
+      postgame: { status: 'tryagain' | 'youwin' };
     }
   }
 }

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,0 +1,114 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
+
+import { supabase } from '../lib/supabase';
+import { normalizeEmail } from '../lib/validation';
+
+import { AuthError, Session, User } from '@supabase/supabase-js';
+
+const RESET_REDIRECT = 'wordle://reset-password';
+const CONFIRM_REDIRECT = 'wordle://auth-callback';
+
+type Result = { error: AuthError | null };
+
+type AuthCtx = {
+  session: Session | null;
+  user: User | null;
+  initializing: boolean;
+  signIn: (email: string, password: string) => Promise<Result>;
+  signUp: (email: string, password: string) => Promise<Result>;
+  signOut: () => Promise<Result>;
+  resendConfirmation: (email: string) => Promise<Result>;
+  requestPasswordReset: (email: string) => Promise<Result>;
+  updatePassword: (password: string) => Promise<Result>;
+};
+
+const Ctx = createContext<AuthCtx | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+  const [initializing, setInitializing] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    supabase.auth
+      .getSession()
+      .then(({ data }) => {
+        if (!mounted) return;
+        setSession(data.session);
+      })
+      .finally(() => {
+        if (mounted) setInitializing(false);
+      });
+
+    const { data } = supabase.auth.onAuthStateChange((_event, next) => {
+      setSession(next);
+    });
+
+    return () => {
+      mounted = false;
+      data.subscription.unsubscribe();
+    };
+  }, []);
+
+  const value = useMemo<AuthCtx>(
+    () => ({
+      session,
+      user: session?.user ?? null,
+      initializing,
+      signIn: async (email, password) => {
+        const { error } = await supabase.auth.signInWithPassword({
+          email: normalizeEmail(email),
+          password
+        });
+        return { error };
+      },
+      signUp: async (email, password) => {
+        const { error } = await supabase.auth.signUp({
+          email: normalizeEmail(email),
+          password,
+          options: { emailRedirectTo: CONFIRM_REDIRECT }
+        });
+        return { error };
+      },
+      signOut: async () => {
+        const { error } = await supabase.auth.signOut();
+        return { error };
+      },
+      resendConfirmation: async (email) => {
+        const { error } = await supabase.auth.resend({
+          type: 'signup',
+          email: normalizeEmail(email),
+          options: { emailRedirectTo: CONFIRM_REDIRECT }
+        });
+        return { error };
+      },
+      requestPasswordReset: async (email) => {
+        const { error } = await supabase.auth.resetPasswordForEmail(
+          normalizeEmail(email),
+          { redirectTo: RESET_REDIRECT }
+        );
+        return { error };
+      },
+      updatePassword: async (password) => {
+        const { error } = await supabase.auth.updateUser({ password });
+        return { error };
+      }
+    }),
+    [session, initializing]
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useAuth(): AuthCtx {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error('useAuth must be used inside AuthProvider');
+  return ctx;
+}

--- a/src/lib/authErrors.ts
+++ b/src/lib/authErrors.ts
@@ -1,0 +1,34 @@
+import { AuthError } from '@supabase/supabase-js';
+
+const GENERIC = 'Something went wrong. Please try again.';
+
+export function mapAuthError(err: unknown): string {
+  if (!err) return GENERIC;
+  const e = err as AuthError & { status?: number; code?: string };
+  const msg = (e.message || '').toLowerCase();
+  const code = (e.code || '').toLowerCase();
+
+  if (code === 'invalid_credentials' || msg.includes('invalid login'))
+    return 'Wrong email or password.';
+  if (code === 'email_not_confirmed' || msg.includes('email not confirmed'))
+    return 'Please confirm your email before signing in.';
+  if (
+    code === 'user_already_exists' ||
+    msg.includes('already registered') ||
+    msg.includes('user already')
+  )
+    return 'An account with this email already exists.';
+  if (code === 'weak_password' || msg.includes('password'))
+    return 'Password is too weak. Use at least 8 characters.';
+  if (
+    code === 'over_email_send_rate_limit' ||
+    msg.includes('rate limit') ||
+    msg.includes('too many')
+  )
+    return 'Too many attempts. Please wait a moment and try again.';
+  if (msg.includes('network') || msg.includes('fetch'))
+    return 'Network error. Check your connection.';
+  if (e.status === 422) return 'Invalid email or password.';
+
+  return GENERIC;
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,8 +1,62 @@
 import 'react-native-url-polyfill/auto';
+
+import { AppState, Platform } from 'react-native';
+
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import * as SecureStore from 'expo-secure-store';
 
 const url = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const key = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+
+const CHUNK_SIZE = 1800;
+
+function chunkKey(base: string, i: number) {
+  return `${base}.${i}`;
+}
+
+const SecureStorageAdapter = {
+  async getItem(k: string): Promise<string | null> {
+    const meta = await SecureStore.getItemAsync(k);
+    if (!meta) return null;
+    if (!meta.startsWith('__chunks__:')) return meta;
+    const count = Number(meta.slice('__chunks__:'.length));
+    if (!Number.isFinite(count) || count <= 0) return null;
+    const parts: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const part = await SecureStore.getItemAsync(chunkKey(k, i));
+      if (part == null) return null;
+      parts.push(part);
+    }
+    return parts.join('');
+  },
+  async setItem(k: string, value: string): Promise<void> {
+    await this.removeItem(k);
+    if (value.length <= CHUNK_SIZE) {
+      await SecureStore.setItemAsync(k, value);
+      return;
+    }
+    const count = Math.ceil(value.length / CHUNK_SIZE);
+    for (let i = 0; i < count; i++) {
+      await SecureStore.setItemAsync(
+        chunkKey(k, i),
+        value.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE)
+      );
+    }
+    await SecureStore.setItemAsync(k, `__chunks__:${count}`);
+  },
+  async removeItem(k: string): Promise<void> {
+    const meta = await SecureStore.getItemAsync(k);
+    if (meta && meta.startsWith('__chunks__:')) {
+      const count = Number(meta.slice('__chunks__:'.length));
+      if (Number.isFinite(count)) {
+        for (let i = 0; i < count; i++) {
+          await SecureStore.deleteItemAsync(chunkKey(k, i));
+        }
+      }
+    }
+    await SecureStore.deleteItemAsync(k);
+  }
+};
 
 function missing(): never {
   throw new Error(
@@ -13,11 +67,27 @@ function missing(): never {
 export const supabase: SupabaseClient =
   url && key
     ? createClient(url, key, {
-        auth: { persistSession: false, autoRefreshToken: false }
+        auth: {
+          storage: SecureStorageAdapter,
+          persistSession: true,
+          autoRefreshToken: true,
+          detectSessionInUrl: false,
+          flowType: 'pkce'
+        }
       })
     : (new Proxy({} as SupabaseClient, { get: missing }) as SupabaseClient);
 
 if (!url || !key) {
   // eslint-disable-next-line no-console
   console.warn('[supabase] env not set — client will throw when used');
+}
+
+if (url && key && Platform.OS !== 'web') {
+  AppState.addEventListener('change', (state) => {
+    if (state === 'active') {
+      supabase.auth.startAutoRefresh();
+    } else {
+      supabase.auth.stopAutoRefresh();
+    }
+  });
 }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,33 @@
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const MAX_EMAIL_LEN = 254;
+export const MIN_PASSWORD_LEN = 8;
+export const MAX_PASSWORD_LEN = 128;
+
+export function normalizeEmail(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
+export function validateEmail(raw: string): string | null {
+  const email = normalizeEmail(raw);
+  if (!email) return 'Enter your email.';
+  if (email.length > MAX_EMAIL_LEN) return 'Email is too long.';
+  if (!EMAIL_RE.test(email)) return 'Enter a valid email.';
+  return null;
+}
+
+export function validatePassword(pwd: string): string | null {
+  if (!pwd) return 'Enter a password.';
+  if (pwd.length < MIN_PASSWORD_LEN)
+    return `Password must be at least ${MIN_PASSWORD_LEN} characters.`;
+  if (pwd.length > MAX_PASSWORD_LEN) return 'Password is too long.';
+  return null;
+}
+
+export function validatePasswordConfirm(
+  pwd: string,
+  confirm: string
+): string | null {
+  if (pwd !== confirm) return 'Passwords do not match.';
+  return null;
+}

--- a/src/routes/app.routes.tsx
+++ b/src/routes/app.routes.tsx
@@ -1,3 +1,4 @@
+import ResetPassword from '../screens/Auth/ResetPassword';
 import Home from '../screens/Home';
 import Postgame from '../screens/PostGame';
 
@@ -5,11 +6,17 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 const { Navigator, Screen } = createNativeStackNavigator();
 
-export function AppRoutes() {
+type Props = { initialRouteName?: 'home' | 'resetPassword' };
+
+export function AppRoutes({ initialRouteName = 'home' }: Props) {
   return (
-    <Navigator screenOptions={{ headerShown: false }}>
+    <Navigator
+      initialRouteName={initialRouteName}
+      screenOptions={{ headerShown: false }}
+    >
       <Screen name="home" component={Home} />
       <Screen name="postgame" component={Postgame} />
+      <Screen name="resetPassword" component={ResetPassword} />
     </Navigator>
   );
 }

--- a/src/routes/auth.routes.tsx
+++ b/src/routes/auth.routes.tsx
@@ -1,0 +1,19 @@
+import CheckEmail from '../screens/Auth/CheckEmail';
+import ForgotPassword from '../screens/Auth/ForgotPassword';
+import SignIn from '../screens/Auth/SignIn';
+import SignUp from '../screens/Auth/SignUp';
+
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+const { Navigator, Screen } = createNativeStackNavigator();
+
+export function AuthRoutes() {
+  return (
+    <Navigator screenOptions={{ headerShown: false }}>
+      <Screen name="signIn" component={SignIn} />
+      <Screen name="signUp" component={SignUp} />
+      <Screen name="forgotPassword" component={ForgotPassword} />
+      <Screen name="checkEmail" component={CheckEmail} />
+    </Navigator>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,14 +1,85 @@
+import React, { useEffect, useState } from 'react';
+import { Linking } from 'react-native';
+
+import { Loading } from '../components/Loading';
+
+import { AuthProvider, useAuth } from '../hooks/useAuth';
+import { supabase } from '../lib/supabase';
 import { AppRoutes } from './app.routes';
+import { AuthRoutes } from './auth.routes';
 import { Container } from './style';
 
 import { NavigationContainer } from '@react-navigation/native';
 
+function extractCode(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    return parsed.searchParams.get('code');
+  } catch {
+    return null;
+  }
+}
+
+function isResetLink(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname === 'reset-password' ||
+      parsed.pathname.includes('reset-password')
+    );
+  } catch {
+    return false;
+  }
+}
+
+function RoutesInner() {
+  const { session, initializing } = useAuth();
+  const [pendingReset, setPendingReset] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    async function handleUrl(url: string | null) {
+      if (!url || !active) return;
+      const code = extractCode(url);
+      if (!code) return;
+      const reset = isResetLink(url);
+      if (reset) setPendingReset(true);
+      const { error } = await supabase.auth.exchangeCodeForSession(code);
+      if (error) {
+        // eslint-disable-next-line no-console
+        console.warn('[auth] exchange failed:', error.message);
+        if (reset && active) setPendingReset(false);
+      }
+    }
+
+    Linking.getInitialURL().then(handleUrl);
+    const sub = Linking.addEventListener('url', ({ url }) => handleUrl(url));
+    return () => {
+      active = false;
+      sub.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!session && pendingReset) setPendingReset(false);
+  }, [session, pendingReset]);
+
+  if (initializing) return <Loading />;
+  if (!session) return <AuthRoutes />;
+  return (
+    <AppRoutes initialRouteName={pendingReset ? 'resetPassword' : 'home'} />
+  );
+}
+
 export function Routes() {
   return (
     <Container>
-      <NavigationContainer>
-        <AppRoutes />
-      </NavigationContainer>
+      <AuthProvider>
+        <NavigationContainer>
+          <RoutesInner />
+        </NavigationContainer>
+      </AuthProvider>
     </Container>
   );
 }

--- a/src/screens/Auth/CheckEmail.tsx
+++ b/src/screens/Auth/CheckEmail.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { View } from 'react-native';
+
+import { useAuth } from '../../hooks/useAuth';
+import { mapAuthError } from '../../lib/authErrors';
+import {
+  Container,
+  ErrorText,
+  InfoText,
+  LinkButton,
+  LinkText,
+  MutedLink,
+  PrimaryButton,
+  PrimaryButtonText,
+  Subtitle,
+  Title
+} from './styles';
+
+import { useNavigation, useRoute } from '@react-navigation/native';
+
+export default function CheckEmail() {
+  const { navigate } = useNavigation();
+  const route = useRoute<{
+    key: string;
+    name: string;
+    params?: { email?: string };
+  }>();
+  const email = route.params?.email ?? '';
+  const { resendConfirmation } = useAuth();
+
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function onResend() {
+    if (!email) return;
+    setErr(null);
+    setSent(false);
+    setLoading(true);
+    const { error } = await resendConfirmation(email);
+    setLoading(false);
+    if (error) {
+      setErr(mapAuthError(error));
+      return;
+    }
+    setSent(true);
+  }
+
+  return (
+    <Container edges={['top', 'bottom']}>
+      <View style={{ flex: 1, justifyContent: 'center' }}>
+        <Title>Check your email</Title>
+        <Subtitle>
+          {email
+            ? `We sent a confirmation link to ${email}. Tap it to activate your account.`
+            : 'We sent you a confirmation link. Tap it to activate your account.'}
+        </Subtitle>
+
+        {sent && <InfoText>Confirmation email resent.</InfoText>}
+        {err && <ErrorText>{err}</ErrorText>}
+
+        <PrimaryButton
+          activeOpacity={0.8}
+          onPress={onResend}
+          disabled={loading || !email}
+          $disabled={loading || !email}
+        >
+          <PrimaryButtonText>
+            {loading ? 'Resending…' : 'Resend email'}
+          </PrimaryButtonText>
+        </PrimaryButton>
+
+        <LinkButton onPress={() => navigate('signIn')}>
+          <MutedLink>
+            Back to <LinkText>Sign in</LinkText>
+          </MutedLink>
+        </LinkButton>
+      </View>
+    </Container>
+  );
+}

--- a/src/screens/Auth/ForgotPassword.tsx
+++ b/src/screens/Auth/ForgotPassword.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
+
+import { useAuth } from '../../hooks/useAuth';
+import { mapAuthError } from '../../lib/authErrors';
+import { validateEmail } from '../../lib/validation';
+import {
+  Container,
+  ErrorText,
+  InfoText,
+  Input,
+  Label,
+  LinkButton,
+  LinkText,
+  MutedLink,
+  PrimaryButton,
+  PrimaryButtonText,
+  Subtitle,
+  Title
+} from './styles';
+
+import { useNavigation } from '@react-navigation/native';
+
+export default function ForgotPassword() {
+  const { navigate } = useNavigation();
+  const { requestPasswordReset } = useAuth();
+
+  const [email, setEmail] = useState('');
+  const [emailErr, setEmailErr] = useState<string | null>(null);
+  const [formErr, setFormErr] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit() {
+    setFormErr(null);
+    const ee = validateEmail(email);
+    setEmailErr(ee);
+    if (ee) return;
+
+    setLoading(true);
+    const { error } = await requestPasswordReset(email);
+    setLoading(false);
+    if (error) {
+      setFormErr(mapAuthError(error));
+      return;
+    }
+    setSent(true);
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={{ flex: 1, backgroundColor: '#000' }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <Container edges={['top', 'bottom']}>
+        <ScrollView
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={{ flexGrow: 1 }}
+        >
+          <View style={{ flex: 1, justifyContent: 'center' }}>
+            <Title>Reset password</Title>
+            <Subtitle>
+              Enter your email and we will send a reset link if an account
+              exists.
+            </Subtitle>
+
+            <Label>Email</Label>
+            <Input
+              value={email}
+              onChangeText={setEmail}
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="email"
+              textContentType="emailAddress"
+              keyboardType="email-address"
+              placeholder="you@example.com"
+              editable={!loading && !sent}
+              maxLength={254}
+            />
+            {emailErr && <ErrorText>{emailErr}</ErrorText>}
+            {sent && (
+              <InfoText>
+                If an account exists, we sent a reset link to your email.
+              </InfoText>
+            )}
+            {formErr && <ErrorText>{formErr}</ErrorText>}
+
+            <PrimaryButton
+              activeOpacity={0.8}
+              onPress={onSubmit}
+              disabled={loading || sent}
+              $disabled={loading || sent}
+            >
+              <PrimaryButtonText>
+                {loading ? 'Sending…' : sent ? 'Email sent' : 'Send reset link'}
+              </PrimaryButtonText>
+            </PrimaryButton>
+
+            <LinkButton onPress={() => navigate('signIn')}>
+              <MutedLink>
+                Back to <LinkText>Sign in</LinkText>
+              </MutedLink>
+            </LinkButton>
+          </View>
+        </ScrollView>
+      </Container>
+    </KeyboardAvoidingView>
+  );
+}

--- a/src/screens/Auth/ResetPassword.tsx
+++ b/src/screens/Auth/ResetPassword.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
+
+import { useAuth } from '../../hooks/useAuth';
+import { mapAuthError } from '../../lib/authErrors';
+import {
+  validatePassword,
+  validatePasswordConfirm
+} from '../../lib/validation';
+import {
+  Container,
+  ErrorText,
+  InfoText,
+  Input,
+  Label,
+  PrimaryButton,
+  PrimaryButtonText,
+  Subtitle,
+  Title
+} from './styles';
+
+export default function ResetPassword() {
+  const { updatePassword, session } = useAuth();
+
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [pwdErr, setPwdErr] = useState<string | null>(null);
+  const [confirmErr, setConfirmErr] = useState<string | null>(null);
+  const [formErr, setFormErr] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit() {
+    setFormErr(null);
+    const pe = validatePassword(password);
+    const ce = validatePasswordConfirm(password, confirm);
+    setPwdErr(pe);
+    setConfirmErr(ce);
+    if (pe || ce) return;
+
+    setLoading(true);
+    const { error } = await updatePassword(password);
+    setLoading(false);
+    if (error) {
+      setFormErr(mapAuthError(error));
+      return;
+    }
+    setDone(true);
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={{ flex: 1, backgroundColor: '#000' }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <Container edges={['top', 'bottom']}>
+        <ScrollView
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={{ flexGrow: 1 }}
+        >
+          <View style={{ flex: 1, justifyContent: 'center' }}>
+            <Title>Set new password</Title>
+            <Subtitle>
+              {session
+                ? 'Choose a new password for your account.'
+                : 'Open the reset link from your email on this device to continue.'}
+            </Subtitle>
+
+            <Label>New password</Label>
+            <Input
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="password-new"
+              textContentType="newPassword"
+              placeholder="At least 8 characters"
+              editable={!loading && !!session && !done}
+              maxLength={128}
+            />
+            {pwdErr && <ErrorText>{pwdErr}</ErrorText>}
+
+            <Label>Confirm password</Label>
+            <Input
+              value={confirm}
+              onChangeText={setConfirm}
+              secureTextEntry
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="password-new"
+              textContentType="newPassword"
+              placeholder="Repeat your password"
+              editable={!loading && !!session && !done}
+              maxLength={128}
+            />
+            {confirmErr && <ErrorText>{confirmErr}</ErrorText>}
+
+            {done && <InfoText>Password updated. You can play now.</InfoText>}
+            {formErr && <ErrorText>{formErr}</ErrorText>}
+
+            <PrimaryButton
+              activeOpacity={0.8}
+              onPress={onSubmit}
+              disabled={loading || !session || done}
+              $disabled={loading || !session || done}
+            >
+              <PrimaryButtonText>
+                {loading ? 'Updating…' : done ? 'Done' : 'Update password'}
+              </PrimaryButtonText>
+            </PrimaryButton>
+          </View>
+        </ScrollView>
+      </Container>
+    </KeyboardAvoidingView>
+  );
+}

--- a/src/screens/Auth/SignIn.tsx
+++ b/src/screens/Auth/SignIn.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
+
+import { useAuth } from '../../hooks/useAuth';
+import { mapAuthError } from '../../lib/authErrors';
+import { validateEmail } from '../../lib/validation';
+import {
+  Container,
+  ErrorText,
+  Input,
+  Label,
+  LinkButton,
+  LinkText,
+  MutedLink,
+  PrimaryButton,
+  PrimaryButtonText,
+  Subtitle,
+  Title
+} from './styles';
+
+import { useNavigation } from '@react-navigation/native';
+
+export default function SignIn() {
+  const { navigate } = useNavigation();
+  const { signIn } = useAuth();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [emailErr, setEmailErr] = useState<string | null>(null);
+  const [pwdErr, setPwdErr] = useState<string | null>(null);
+  const [formErr, setFormErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit() {
+    setFormErr(null);
+    const ee = validateEmail(email);
+    const pe = password ? null : 'Enter your password.';
+    setEmailErr(ee);
+    setPwdErr(pe);
+    if (ee || pe) return;
+
+    setLoading(true);
+    const { error } = await signIn(email, password);
+    setLoading(false);
+    if (error) setFormErr(mapAuthError(error));
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={{ flex: 1, backgroundColor: '#000' }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <Container edges={['top', 'bottom']}>
+        <ScrollView
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={{ flexGrow: 1 }}
+        >
+          <View style={{ flex: 1, justifyContent: 'center' }}>
+            <Title>Welcome back</Title>
+            <Subtitle>Sign in to continue playing.</Subtitle>
+
+            <Label>Email</Label>
+            <Input
+              value={email}
+              onChangeText={setEmail}
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="email"
+              textContentType="emailAddress"
+              keyboardType="email-address"
+              placeholder="you@example.com"
+              editable={!loading}
+              maxLength={254}
+            />
+            {emailErr && <ErrorText>{emailErr}</ErrorText>}
+
+            <Label>Password</Label>
+            <Input
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="password"
+              textContentType="password"
+              placeholder="At least 8 characters"
+              editable={!loading}
+              maxLength={128}
+            />
+            {pwdErr && <ErrorText>{pwdErr}</ErrorText>}
+
+            {formErr && <ErrorText>{formErr}</ErrorText>}
+
+            <PrimaryButton
+              activeOpacity={0.8}
+              onPress={onSubmit}
+              disabled={loading}
+              $disabled={loading}
+            >
+              <PrimaryButtonText>
+                {loading ? 'Signing in…' : 'Sign in'}
+              </PrimaryButtonText>
+            </PrimaryButton>
+
+            <LinkButton onPress={() => navigate('forgotPassword')}>
+              <LinkText>Forgot your password?</LinkText>
+            </LinkButton>
+
+            <LinkButton onPress={() => navigate('signUp')}>
+              <MutedLink>
+                Don&apos;t have an account? <LinkText>Sign up</LinkText>
+              </MutedLink>
+            </LinkButton>
+          </View>
+        </ScrollView>
+      </Container>
+    </KeyboardAvoidingView>
+  );
+}

--- a/src/screens/Auth/SignUp.tsx
+++ b/src/screens/Auth/SignUp.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react';
+import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
+
+import { useAuth } from '../../hooks/useAuth';
+import { mapAuthError } from '../../lib/authErrors';
+import {
+  normalizeEmail,
+  validateEmail,
+  validatePassword,
+  validatePasswordConfirm
+} from '../../lib/validation';
+import {
+  Container,
+  ErrorText,
+  Input,
+  Label,
+  LinkButton,
+  LinkText,
+  MutedLink,
+  PrimaryButton,
+  PrimaryButtonText,
+  Subtitle,
+  Title
+} from './styles';
+
+import { useNavigation } from '@react-navigation/native';
+
+export default function SignUp() {
+  const { navigate } = useNavigation();
+  const { signUp } = useAuth();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [emailErr, setEmailErr] = useState<string | null>(null);
+  const [pwdErr, setPwdErr] = useState<string | null>(null);
+  const [confirmErr, setConfirmErr] = useState<string | null>(null);
+  const [formErr, setFormErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit() {
+    setFormErr(null);
+    const ee = validateEmail(email);
+    const pe = validatePassword(password);
+    const ce = validatePasswordConfirm(password, confirm);
+    setEmailErr(ee);
+    setPwdErr(pe);
+    setConfirmErr(ce);
+    if (ee || pe || ce) return;
+
+    setLoading(true);
+    const { error } = await signUp(email, password);
+    setLoading(false);
+    if (error) {
+      setFormErr(mapAuthError(error));
+      return;
+    }
+    navigate('checkEmail', { email: normalizeEmail(email) });
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={{ flex: 1, backgroundColor: '#000' }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <Container edges={['top', 'bottom']}>
+        <ScrollView
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={{ flexGrow: 1 }}
+        >
+          <View style={{ flex: 1, justifyContent: 'center' }}>
+            <Title>Create account</Title>
+            <Subtitle>Sign up with your email and a password.</Subtitle>
+
+            <Label>Email</Label>
+            <Input
+              value={email}
+              onChangeText={setEmail}
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="email"
+              textContentType="emailAddress"
+              keyboardType="email-address"
+              placeholder="you@example.com"
+              editable={!loading}
+              maxLength={254}
+            />
+            {emailErr && <ErrorText>{emailErr}</ErrorText>}
+
+            <Label>Password</Label>
+            <Input
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="password-new"
+              textContentType="newPassword"
+              placeholder="At least 8 characters"
+              editable={!loading}
+              maxLength={128}
+            />
+            {pwdErr && <ErrorText>{pwdErr}</ErrorText>}
+
+            <Label>Confirm password</Label>
+            <Input
+              value={confirm}
+              onChangeText={setConfirm}
+              secureTextEntry
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="password-new"
+              textContentType="newPassword"
+              placeholder="Repeat your password"
+              editable={!loading}
+              maxLength={128}
+            />
+            {confirmErr && <ErrorText>{confirmErr}</ErrorText>}
+
+            {formErr && <ErrorText>{formErr}</ErrorText>}
+
+            <PrimaryButton
+              activeOpacity={0.8}
+              onPress={onSubmit}
+              disabled={loading}
+              $disabled={loading}
+            >
+              <PrimaryButtonText>
+                {loading ? 'Creating…' : 'Create account'}
+              </PrimaryButtonText>
+            </PrimaryButton>
+
+            <LinkButton onPress={() => navigate('signIn')}>
+              <MutedLink>
+                Already have an account? <LinkText>Sign in</LinkText>
+              </MutedLink>
+            </LinkButton>
+          </View>
+        </ScrollView>
+      </Container>
+    </KeyboardAvoidingView>
+  );
+}

--- a/src/screens/Auth/styles.ts
+++ b/src/screens/Auth/styles.ts
@@ -1,0 +1,90 @@
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import styled from 'styled-components/native';
+
+export const Container = styled(SafeAreaView)`
+  flex: 1;
+  background-color: #000;
+  padding: 24px;
+`;
+
+export const Title = styled.Text`
+  color: white;
+  font-size: 32px;
+  font-weight: 800;
+  margin-bottom: 8px;
+`;
+
+export const Subtitle = styled.Text`
+  color: #9b9b9b;
+  font-size: 15px;
+  margin-bottom: 24px;
+`;
+
+export const Label = styled.Text`
+  color: #d6d6d6;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 6px;
+  margin-top: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+`;
+
+export const Input = styled.TextInput.attrs({
+  placeholderTextColor: '#6b6b6b',
+  selectionColor: '#f9ff00'
+})`
+  background-color: #141414;
+  border-width: 1px;
+  border-color: #262626;
+  border-radius: 12px;
+  color: white;
+  padding: 14px 16px;
+  font-size: 16px;
+`;
+
+export const ErrorText = styled.Text`
+  color: #ff6b6b;
+  font-size: 13px;
+  margin-top: 6px;
+`;
+
+export const InfoText = styled.Text`
+  color: #9bff9b;
+  font-size: 13px;
+  margin-top: 6px;
+`;
+
+export const PrimaryButton = styled.TouchableOpacity<{ $disabled?: boolean }>`
+  background-color: #f9ff00;
+  border-radius: 16px;
+  padding: 18px;
+  margin-top: 24px;
+  opacity: ${(p) => (p.$disabled ? 0.5 : 1)};
+`;
+
+export const PrimaryButtonText = styled.Text`
+  color: black;
+  text-align: center;
+  font-size: 16px;
+  font-weight: 700;
+`;
+
+export const LinkButton = styled.TouchableOpacity`
+  padding: 14px;
+  align-items: center;
+`;
+
+export const LinkText = styled.Text`
+  color: #f9ff00;
+  font-size: 14px;
+  font-weight: 600;
+`;
+
+export const MutedLink = styled.Text`
+  color: #9b9b9b;
+  font-size: 13px;
+  text-align: center;
+  margin-top: 12px;
+`;


### PR DESCRIPTION
Closes #4

## Summary
Adds email + password authentication backed by Supabase, covering sign-up, sign-in, email confirmation, password reset, and session persistence.

## What's included
- **Secure session storage** — `expo-secure-store` adapter with chunking to bypass iOS 2KB Keychain item limit. PKCE flow (`flowType: 'pkce'`, `detectSessionInUrl: false`). `AppState` wired to `startAutoRefresh`/`stopAutoRefresh`.
- **Auth context** — `AuthProvider` exposing `session`, `user`, `initializing`, `signIn`, `signUp`, `signOut`, `resendConfirmation`, `requestPasswordReset`, `updatePassword`. Subscribes to `onAuthStateChange`.
- **Validation + error mapping** — email format (RFC-lite), password length 8-128, normalized email (trim + lowercase). Supabase `AuthError` mapped to user-friendly copy (wrong credentials, email not confirmed, account exists, rate limit, network).
- **Screens** — `SignIn`, `SignUp`, `ForgotPassword`, `ResetPassword`, `CheckEmail`. Keyboard-aware, `secureTextEntry`, `autoCapitalize=none`, `autoComplete` + `textContentType` hints for password managers, `maxLength` caps.
- **Route split** — `AuthRoutes` (unauthenticated) vs `AppRoutes` (authenticated). Root container gates on `session`. Deep-link handler exchanges PKCE code (`exchangeCodeForSession`) and selects `initialRouteName` dynamically so reset flows land on `resetPassword` without navigation race conditions.

## Security notes
- Tokens stored in OS Keychain/Keystore, never AsyncStorage.
- PKCE prevents tokens in URL fragments.
- Forgot-password response is generic ("if an account exists…") to avoid user enumeration.
- Passwords never logged; only error messages surfaced.
- Submit buttons disabled during async calls; client-side validation runs before network.
- Length caps prevent excessive payloads; `secureTextEntry` + clipboard-safe text input patterns.

## Required dashboard configuration
- Add `wordle://reset-password` and `wordle://auth-callback` to Supabase **Redirect URL allow-list**.
- Enable email confirmation + password reset email templates.

## Out of scope (deferred)
- Biometric lock / MFA.
- Client-side rate limiting (Supabase enforces server-side).
- Password visibility toggle.
- HIBP / complexity policy beyond length.

## Test plan
- [ ] Build dev client (`expo run:ios` / `expo run:android`) — `expo-secure-store` is a native module, Expo Go will not work.
- [ ] Sign up with a new email → check confirmation email received.
- [ ] Tap confirmation link → app deep-links, user is signed in, lands on `home`.
- [ ] Sign in with wrong password → `Wrong email or password.` shown.
- [ ] Sign in before confirming email → `Please confirm your email before signing in.` shown.
- [ ] Forgot password → email sent → tap link → app opens `resetPassword` → set new password → return to `home`.
- [ ] Kill app + reopen → session persists (no re-login).
- [ ] Background + foreground → token auto-refresh continues.
- [ ] Validation: empty email, invalid email, password < 8 chars, mismatched confirm — each surfaces inline error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)