### PR TITLE
feat(auth): add sign-out button in header

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,11 +1,29 @@
 import Logo from '../../../assets/Logo.svg';
-import { Container, Text } from './style';
+import { useAuth } from '../../hooks/useAuth';
+import { Container, LogoGroup, SignOutButton, Spacer, Text } from './style';
+
+import { SignOut } from 'phosphor-react-native';
 
 export default function Header() {
+  const { signOut } = useAuth();
+
   return (
     <Container>
-      <Logo />
-      <Text>ordle</Text>
+      <Spacer />
+      <LogoGroup>
+        <Logo />
+        <Text>ordle</Text>
+      </LogoGroup>
+      <SignOutButton
+        onPress={() => {
+          signOut();
+        }}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel="Sign out"
+      >
+        <SignOut size={24} color="#ffffff" weight="regular" />
+      </SignOutButton>
     </Container>
   );
 }

--- a/src/components/Header/style.ts
+++ b/src/components/Header/style.ts
@@ -1,13 +1,33 @@
 import styled from 'styled-components/native';
 
+const SIDE_SLOT = 40;
+
 export const Container = styled.View`
   flex-direction: row;
-  gap: 6px;
   padding: 12px 20px 20px 20px;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
   border-bottom-width: 1px;
   border-bottom-color: #1f1f1f;
+`;
+
+export const Spacer = styled.View`
+  width: ${SIDE_SLOT}px;
+`;
+
+export const LogoGroup = styled.View`
+  flex: 1;
+  flex-direction: row;
+  gap: 6px;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const SignOutButton = styled.Pressable`
+  width: ${SIDE_SLOT}px;
+  height: ${SIDE_SLOT}px;
+  align-items: center;
+  justify-content: center;
 `;
 
 export const Text = styled.Text`


### PR DESCRIPTION
## Summary
- Add a sign-out action to the `Header` component so authenticated users can end their session from the Home screen.
- The button uses the `SignOut` icon from `phosphor-react-native` and triggers `useAuth().signOut()`; route gating in `src/routes/index.tsx` auto-navigates to the auth stack when the session clears.
- Header layout becomes a three-slot row (left spacer / centered logo group / sign-out button) so the logo stays visually centered.

Closes #5.

### Issue #5 acceptance
- [x] Session stored via `expo-secure-store` — already implemented in `src/lib/supabase.ts` (`SecureStorageAdapter`).
- [x] App restores session on cold start — handled by `getSession()` + `initializing` gate in `src/hooks/useAuth.tsx` / `src/routes/index.tsx`.
- [x] Sign-out button clears session and navigates to auth screen — added in this PR.
- [x] Expired / invalid session routes user to auth screen — `autoRefreshToken` + `onAuthStateChange` already route to `<AuthRoutes />` when session becomes `null`.

## Test plan
- [ ] `npm run ios` (or `android`), sign in, tap the sign-out icon in the header → app swaps to the sign-in screen.
- [ ] Sign in, fully kill and relaunch the app → brief `<Loading />`, then lands on Home without re-entering credentials.
- [ ] Revoke the refresh token in Supabase (or wait past expiry) → next auto-refresh emits `SIGNED_OUT` and the app routes to sign-in.
- [ ] `npm run lint` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)