### PR TITLE
refactor(auth): rename initializing to loading

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -19,7 +19,7 @@ type Result = { error: AuthError | null };
 type AuthCtx = {
   session: Session | null;
   user: User | null;
-  initializing: boolean;
+  loading: boolean;
   signIn: (email: string, password: string) => Promise<Result>;
   signUp: (email: string, password: string) => Promise<Result>;
   signOut: () => Promise<Result>;
@@ -32,7 +32,7 @@ const Ctx = createContext<AuthCtx | null>(null);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
-  const [initializing, setInitializing] = useState(true);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     let mounted = true;
@@ -44,7 +44,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setSession(data.session);
       })
       .finally(() => {
-        if (mounted) setInitializing(false);
+        if (mounted) setLoading(false);
       });
 
     const { data } = supabase.auth.onAuthStateChange((_event, next) => {
@@ -61,7 +61,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     () => ({
       session,
       user: session?.user ?? null,
-      initializing,
+      loading,
       signIn: async (email, password) => {
         const { error } = await supabase.auth.signInWithPassword({
           email: normalizeEmail(email),
@@ -101,7 +101,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return { error };
       }
     }),
-    [session, initializing]
+    [session, loading]
   );
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -33,7 +33,7 @@ function isResetLink(url: string): boolean {
 }
 
 function RoutesInner() {
-  const { session, initializing } = useAuth();
+  const { session, loading } = useAuth();
   const [pendingReset, setPendingReset] = useState(false);
 
   useEffect(() => {
@@ -65,7 +65,7 @@ function RoutesInner() {
     if (!session && pendingReset) setPendingReset(false);
   }, [session, pendingReset]);
 
-  if (initializing) return <Loading />;
+  if (loading) return <Loading />;
   if (!session) return <AuthRoutes />;
   return (
     <AppRoutes initialRouteName={pendingReset ? 'resetPassword' : 'home'} />


### PR DESCRIPTION
## Summary
- Rename `initializing` → `loading` in `AuthProvider` context to match the spec field name (`{ user, session, loading, signIn*, signOut }`).
- Update consumer in `src/routes/index.tsx`.

## Acceptance (issue #6)
- [x] `AuthProvider` wraps app, exposes `{ user, session, loading, signIn*, signOut }`.
- [x] Unauthenticated users see only the auth screen.
- [x] Authenticated users see main stack.
- [x] Navigating on sign-in / sign-out works without remount glitches — `NavigationContainer` stays mounted while `AuthRoutes` / `AppRoutes` swap on session change.

Closes #6

## Test plan
- [ ] Cold start with no session → auth stack
- [ ] Sign in → app stack mounts at `home`
- [ ] Sign out from header → returns to auth stack
- [ ] Reset-password deep link → app stack mounts at `resetPassword`

🤖 Generated with [Claude Code](https://claude.com/claude-code)