### PR TITLE
chore(ci): GitHub Actions — lint + typecheck on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit


### PR DESCRIPTION
## Summary
- New `.github/workflows/ci.yml` runs on PRs targeting `main`.
- Steps: checkout, Node 20 with npm cache, `npm ci`, `npm run lint`, `npx tsc --noEmit`.

## Closes
#23

## Notes
- Required-status-check on `main` must be enabled in the repo's branch protection settings (UI step, not in this PR).
- Pairs naturally with #29 (typescript-eslint v8 bump). CI passes on either order — `npx tsc --noEmit` is used directly so it does not require the new `typecheck` script.

## Test plan
- [ ] CI run triggered by this PR is green
- [ ] Workflow shows up under Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)