### PR TITLE
feat(toast): reusable Toast component + provider

### DIFF
--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+import { Animated } from 'react-native';
+
+import { Bubble, Message, Wrapper } from './style';
+
+export type ToastTone = 'info' | 'success' | 'error';
+
+type Props = {
+  message: string;
+  tone?: ToastTone;
+  visible: boolean;
+};
+
+export function Toast({ message, tone = 'info', visible }: Props) {
+  const opacity = useRef(new Animated.Value(0)).current;
+  const translate = useRef(new Animated.Value(12)).current;
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.timing(opacity, {
+        toValue: visible ? 1 : 0,
+        duration: 180,
+        useNativeDriver: true
+      }),
+      Animated.timing(translate, {
+        toValue: visible ? 0 : 12,
+        duration: 180,
+        useNativeDriver: true
+      })
+    ]).start();
+  }, [visible, opacity, translate]);
+
+  return (
+    <Wrapper
+      pointerEvents="none"
+      style={{ opacity, transform: [{ translateY: translate }] }}
+    >
+      <Bubble tone={tone}>
+        <Message accessibilityLiveRegion="polite">{message}</Message>
+      </Bubble>
+    </Wrapper>
+  );
+}

--- a/src/components/Toast/style.ts
+++ b/src/components/Toast/style.ts
@@ -1,0 +1,34 @@
+import { Animated } from 'react-native';
+
+import styled from 'styled-components/native';
+
+type ContainerProps = { tone: 'info' | 'success' | 'error' };
+
+const TONE_BG: Record<ContainerProps['tone'], string> = {
+  info: '#1F2937',
+  success: '#15803D',
+  error: '#B91C1C'
+};
+
+export const Wrapper = styled(Animated.View)`
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 48px;
+  align-items: center;
+  z-index: 1000;
+`;
+
+export const Bubble = styled.View<ContainerProps>`
+  background-color: ${(p) => TONE_BG[p.tone]};
+  padding: 12px 20px;
+  border-radius: 24px;
+  max-width: 100%;
+`;
+
+export const Message = styled.Text`
+  color: #f9fafb;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+`;

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -1,0 +1,57 @@
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState
+} from 'react';
+
+import { Toast, ToastTone } from '../components/Toast';
+
+type ShowOptions = { tone?: ToastTone; durationMs?: number };
+
+type ToastCtx = {
+  show: (message: string, options?: ShowOptions) => void;
+};
+
+const Ctx = createContext<ToastCtx | null>(null);
+
+const DEFAULT_DURATION_MS = 2000;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [message, setMessage] = useState('');
+  const [tone, setTone] = useState<ToastTone>('info');
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const show = useCallback<ToastCtx['show']>((next, options) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setMessage(next);
+    setTone(options?.tone ?? 'info');
+    setVisible(true);
+    timerRef.current = setTimeout(() => {
+      setVisible(false);
+    }, options?.durationMs ?? DEFAULT_DURATION_MS);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return (
+    <Ctx.Provider value={{ show }}>
+      {children}
+      <Toast message={message} tone={tone} visible={visible} />
+    </Ctx.Provider>
+  );
+}
+
+export function useToast(): ToastCtx {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error('useToast must be used inside ToastProvider');
+  return ctx;
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -4,6 +4,7 @@ import { Linking } from 'react-native';
 import { Loading } from '../components/Loading';
 
 import { AuthProvider, useAuth } from '../hooks/useAuth';
+import { ToastProvider } from '../hooks/useToast';
 import { supabase } from '../lib/supabase';
 import { AppRoutes } from './app.routes';
 import { AuthRoutes } from './auth.routes';
@@ -76,9 +77,11 @@ export function Routes() {
   return (
     <Container>
       <AuthProvider>
-        <NavigationContainer>
-          <RoutesInner />
-        </NavigationContainer>
+        <ToastProvider>
+          <NavigationContainer>
+            <RoutesInner />
+          </NavigationContainer>
+        </ToastProvider>
       </AuthProvider>
     </Container>
   );


### PR DESCRIPTION
## Summary
- New `Toast` component (`src/components/Toast/`) — fade + slide-up animation, tone-colored bubble (info / success / error).
- New `ToastProvider` + `useToast()` hook (`src/hooks/useToast.tsx`) — `show(message, { tone?, durationMs? })`, default 2s auto-dismiss, replaces any in-flight toast.
- Mounted at app root in `src/routes/index.tsx` (inside `AuthProvider`, outside `NavigationContainer`) so any screen can call it.

## Closes
#18

## Follow-ups
- #16 will call `useToast().show('Not in word list', { tone: 'error' })` on invalid guesses.
- #17 will call `useToast().show('Copied!', { tone: 'success' })` after share copy.

## Test plan
- [ ] `npm run lint` exits 0
- [ ] `npx tsc --noEmit` exits 0
- [ ] Manual: temporarily call `useToast().show('test')` in `Home` — toast fades in at bottom, dismisses after ~2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)