### PR TITLE
chore(scripts): ios rebuild helpers for native binary drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
+    "start:clear": "expo start --clear",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
+    "pods": "cd ios && pod install",
+    "ios:clean": "rm -rf ~/Library/Developer/Xcode/DerivedData/Wordle-* ios/build && npx expo run:ios",
+    "ios:reset": "npx expo prebuild --clean -p ios && npm run ios:clean",
     "lint": "eslint . --ext .js,.ts,.tsx",
     "lint:fix": "eslint . --ext .js,.ts,.tsx --fix",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Context
After dependency installs or branch switches, the iOS dev client binary in DerivedData can lag the current JS bundle / Pods, producing:

> `Invariant Violation: TurboModuleRegistry.getEnforcing(...): 'PlatformConstants' could not be found.`

Code change won't fix it — the iOS app needs to be rebuilt against the current native module list.

## Summary
- `npm run start:clear` — `expo start --clear` (wipe Metro cache).
- `npm run pods` — shortcut for `cd ios && pod install`.
- `npm run ios:clean` — wipe DerivedData + `ios/build`, then `expo run:ios`. **Run this when you hit the PlatformConstants error.**
- `npm run ios:reset` — full `expo prebuild --clean -p ios` then `ios:clean`. Use when even DerivedData wipe doesn't clear it (Podfile drift / corrupted ios/).

## Test plan
- [ ] Hit the PlatformConstants error
- [ ] `npm run ios:clean` → app boots cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)